### PR TITLE
Automatically limit context window size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 steamship==2.15.0
 openai==0.27.2
 tenacity==8.2.0
+tiktoken==0.2.0

--- a/src/prompt_harness.py
+++ b/src/prompt_harness.py
@@ -1,0 +1,9 @@
+from steamship import Steamship
+
+steamship = Steamship()
+gpt4 = steamship.use_plugin("gpt-4", config={"max_tokens":1024})
+while True:
+	prompt = input("Prompt: ")
+	task = gpt4.generate(text=prompt)
+	task.wait()
+	print(task.output.blocks[0].text)


### PR DESCRIPTION
This PR allows the plugin to automatically limit the context window size (if configured to do so).

The idea is to keep all of the system prompts, and then as many of the remaining prompts as fit into the context window.

It's turned off by default because IMO it can lead to some unintuitive behavior.