### PR TITLE
fix(function calls): add proper support for sending function messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-steamship==2.17.8
+steamship==2.17.22
 openai==0.27.8
 tenacity==8.2.2

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "gpt-4",
-	"version": "0.1.0",
+	"version": "0.1.0-rc.12",
 	"description": "",
 	"author": "dave",
 	"entrypoint": "Unused",

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 from steamship import Block, File, Steamship, MimeTypes, Tag
 from steamship.data import TagKind
-from steamship.data.tags.tag_constants import RoleTag
+from steamship.data.tags.tag_constants import RoleTag, TagValueKey
 
 GENERATOR_HANDLE = "gpt-4"
 
@@ -144,8 +144,14 @@ def test_multimodal_functions_with_blocks():
                     mime_type=MimeTypes.TXT,
                 ),
                 Block(
+                    text=json.dumps({"name": "generate_image", "arguments": "{ \"text\": \"sailboat\" }"}),
+                    tags=[Tag(kind=TagKind.ROLE, name=RoleTag.ASSISTANT),
+                          Tag(kind="function-selection", name="generate_image")],
+                    mime_type=MimeTypes.PNG,
+                ),
+                Block(
                     text="c2f6818c-233d-4426-9dc5-f3c28fa33068",
-                    tags=[Tag(kind=TagKind.ROLE, name="function"), Tag(kind="name", name="generate_image")],
+                    tags=[Tag(kind=TagKind.ROLE, name="function", value={TagValueKey.STRING_VALUE: "generate_image"})],
                     mime_type=MimeTypes.PNG,
                 ),
                 Block(
@@ -228,13 +234,14 @@ def test_functions_function_message():
                     tags=[Tag(kind="role", name="user")],
                 ),
                 Block(
-                    text='{"function_call": {"name": "Search", "arguments": "{\\n  \\"__arg1\\": \\"Vin Diesel\'s girlfriend\\"\\n}"}}',
-                    tags=[Tag(kind="role", name="assistant")],
+                    text=json.dumps({"name": "Search", "arguments": "{ \"query\": \"Vin Diesel\'s girlfriend\" }"}),
+                    tags=[Tag(kind=TagKind.ROLE, name=RoleTag.ASSISTANT),
+                          Tag(kind="function-selection", name="Search")],
                 ),
                 Block(
                     text="Paloma Jiménez",
                     tags=[
-                        Tag(kind="role", name="function"),
+                        Tag(kind="role", name="function"),  # legacy method left for testing / backwards compat
                         Tag(kind="name", name="Search"),
                     ],
                 ),


### PR DESCRIPTION
Prior to this PR, it was not possible to send the assistant message that selected a function to OpenAI via the gpt-4 plugin. The full protocol appears to require that the assistant message be sent.

I suspect this might matter for chained function invocations, etc. This PR sets the stage for a unified `History` object (for streaming) that contains the full set of agent<-->llm interactions.

A slight refactor of the functions labeling is supported. This is from two tags (role and name) to a single tag (role with a value of the name). The legacy pattern is still supported for backwards compatibility.